### PR TITLE
support for 850 code page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "jshint": "^2.8.0",
     "mocha": "^2.3.3"
   },
-  "browser": {
-    "./decoder.js": "./decoder-browser.js"
-  },
   "dependencies": {
     "iconv-lite": "^0.4.15",
     "text-encoding-polyfill": "^0.6.7"


### PR DESCRIPTION
I just want parseDBF to support some code pages, such as 850, which is sometimes used in some shapefiles. On server side of the master, 850 code page is supported by 'iconv-lite'. On the other hand, 'TextDecoder' running on client side, doesn't support it. Fortunately, 'iconv-lite' supports to run on the browser now by using Browserify. That's why I just delete the browser field in package.json.